### PR TITLE
Use narginchk instead of nargchk

### DIFF
--- a/+sqlite3/execute.m
+++ b/+sqlite3/execute.m
@@ -17,11 +17,11 @@ function results = execute(varargin)
 %     results = sqlite3.execute(db_id, 'SELECT * FROM records WHERE name = ?', 'foo')
 %
 % See also sqlite3.open sqlite3.close
-  nargchk(1, inf, nargin);
+  narginchk(1, inf);
   if ischar(varargin{1})
     results = libsqlite3_('execute', varargin{1}, varargin(2:end));
   else
-    nargchk(2, inf, nargin);
+    narginchk(2, inf);
     results = libsqlite3_('execute', ...
                           varargin{1}, ...
                           varargin{2}, ...


### PR DESCRIPTION
R2016a (prerelease) displays the following warning:

```
Warning: NARGCHK will be removed in a future release. Use NARGINCHK or NARGOUTCHK instead. 
> In sqlite3.execute (line 20)
```

Regards,
Ivan