### PR TITLE
Truncate long column names

### DIFF
--- a/src/sqlite3mex.cc
+++ b/src/sqlite3mex.cc
@@ -303,12 +303,16 @@ void Database::createColumns(const Statement& statement,
     transform(name.begin(), name.end(), name.begin(), ::tolower);
     if (name.empty())
       name = "field";
+    // Ensure name fits in MATLAB 63-char limit. This truncates and leaves 1 character buffer for up to 10 name collisions below
+    if (name.length() > 62) {
+      name.resize(62);
+    }
     // Find a unique name for the duplicated column.
     int index = 0;
     string original_name(name);
     while (unique_names.find(name) != unique_names.end()) {
       stringstream name_builder(stringstream::in | stringstream::out);
-      name_builder << original_name << "_" << ++index;
+      name_builder << original_name << ++index;
       name = name_builder.str();
     }
     unique_names.insert(name);


### PR DESCRIPTION
This truncates long column names that exceed MATLAB's 63-char limit for identifiers ([namelengthmax](https://www.mathworks.com/help/matlab/ref/namelengthmax.html)). It truncates names exceeding 62 characters, such that if there is a name collision in the truncated form, at least ten unique names can be generated.

I uncovered this issue when working with long column names, and the resulting structure array contains fieldnames that exceed 63 chars. The effect is those field names are visible, but the field simply cannot be accessed (trying to access results in MATLAB indicating no field with the requested name exists). Even requesting the truncated name fails.